### PR TITLE
fix first title is not h1

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -50,11 +50,23 @@ class Extension extends Parsedown
         $text   = $this->fetchText($Content['text']);
         $link   = "[${text}](#${id})";
         $level  = (integer) trim($Content['level'],'h');
+
+        if ($this->firstHeadLevel === 0) {
+            $this->firstHeadLevel = $level;
+        }
+        $cutIndent = $this->firstHeadLevel - 1;
+        if ($cutIndent > $level) {
+            $level = 1;
+        } else {
+            $level = $level - $cutIndent;
+        }
+
         $indent = str_repeat('  ', $level);
 
         $this->contentsListString .= "${indent}- ${link}\n";
     }
     protected $contentsListString = '';
+    protected $firstHeadLevel = 0;
 
     #
     # Header


### PR DESCRIPTION
If the first title is not H1, Then there will be more than four spaces. According to the syntax of markdown, It will be parsed into a block of code.

eg:
```
###title1
####title2
```
output
```
- [title1](#title1)
    - [title2](#title2)
```