### PR TITLE
Use Parsedown Extra anchors identifiers

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -73,7 +73,7 @@ class ParsedownToC extends DynamicParent
     protected function blockHeader($Line)
     {
         if (isset($Line['text'][1])) {
-            $Block = \Parsedown::blockHeader($Line);
+            $Block = DynamicParent::blockHeader($Line);
 
             // Compatibility with old Parsedown Version
             if (isset($Block['element']['handler']['argument'])) {
@@ -85,7 +85,7 @@ class ParsedownToC extends DynamicParent
             }
 
             $level = $Block['element']['name'];    //levels are h1, h2, ..., h6
-            $id    = $this->createAnchorID($text);
+            $id    = $Block['element']['attributes']['id'] ?? $this->createAnchorID($text);
 
             //Set attributes to head tags
             $Block['element']['attributes'] = array(
@@ -106,7 +106,7 @@ class ParsedownToC extends DynamicParent
     // Alias of parent method: \Parsedown::text()
     public function body($text)
     {
-        return \Parsedown::text($text);
+        return DynamicParent::text($text);
     }
 
     public function contentsList($type_return = 'string')

--- a/Extension.php
+++ b/Extension.php
@@ -85,7 +85,8 @@ class ParsedownToC extends DynamicParent
             }
 
             $level = $Block['element']['name'];    //levels are h1, h2, ..., h6
-            $id    = $Block['element']['attributes']['id'] ?? $this->createAnchorID($text);
+            $id    = isset($Block['element']['attributes']['id']) ?
+                $Block['element']['attributes']['id'] : $this->createAnchorID($text);
 
             //Set attributes to head tags
             $Block['element']['attributes'] = array(

--- a/tests/test-parsedownextra_1.sh
+++ b/tests/test-parsedownextra_1.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# =============================================================================
+#  Test: Basic parsing
+# =============================================================================
+
+EXPECT_EQUAL=$YES
+
+SOURCE=$(cat << HEREDOC
+# Head1
+Sample text of head 1.
+## Head1-1
+Sample text of head 1-1.
+# Head2
+Sample text of head 2.
+## 見出し2-1
+Sample text of head2-1.
+# Head3 {#self-defined-head3}
+Sample text of head 3
+HEREDOC
+)
+
+EXPECT=$(cat << HEREDOC
+<ul>
+<li><a href="#Head1">Head1</a>
+<ul>
+<li><a href="#Head1-1">Head1-1</a></li>
+</ul></li>
+<li><a href="#Head2">Head2</a>
+<ul>
+<li><a href="#%E8%A6%8B%E5%87%BA%E3%81%972-1">見出し2-1</a></li>
+</ul></li>
+<li><a href="#self-defined-head3">Head3</a></li>
+</ul>
+HEREDOC
+)

--- a/tests/test-runner/common-tests.sh
+++ b/tests/test-runner/common-tests.sh
@@ -246,6 +246,6 @@ done
 
 echo 'Parsedown Extra'
 
-for file in $(ls test_*.sh); do
+for file in $(ls {test_,test-parsedownextra_}*.sh); do
     runTest "${file}" './parser-extra.php'
 done

--- a/tests/test-runner/run-tests-in-darwin.sh
+++ b/tests/test-runner/run-tests-in-darwin.sh
@@ -34,7 +34,7 @@ echo '- Checking: jq ...'
 which jq > /dev/null 2>&1 || {
     echo '* WARNING: jq command missing'
     echo '- "jq" command is required for testing. Try: $ brew install jq'
-    exiit 1
+    exit 1
 }
 echo -n '  jq installed: '
 jq --version
@@ -43,7 +43,7 @@ echo '- Checking: curl ...'
 which curl > /dev/null 2>&1 || {
     echo '* WARNING: curl command missing'
     echo '- "curl" command is required for testing. Try: $ brew install curl'
-    exiit 1
+    exit 1
 }
 echo -n '  curl installed: '
 curl --version | head -1
@@ -52,7 +52,7 @@ echo '- Checking: tar ...'
 which tar > /dev/null 2>&1 || {
     echo '* WARNING: tar command missing'
     echo '- "tar" command is required for testing. Try: $ brew install tar'
-    exiit 1
+    exit 1
 }
 echo -n '  tar installed: '
 tar --version


### PR DESCRIPTION
This will allow this:
```
# Head1 {#head}
```
To be turned into this:
```
<h1 id="head">Head1</h1>
```
If for some reason they want to set their own identifiers.

See: https://michelf.ca/projects/php-markdown/extra/#header-id