### PR TITLE
Adapting PHP 8.2

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -322,7 +322,7 @@ class ParsedownToC extends DynamicParent
         $text  = $this->fetchText($Content['text']);
         $id    = $Content['id'];
         $level = (integer) trim($Content['level'], 'h');
-        $link  = "[${text}](#${id})";
+        $link  = "[{$text}](#{$id})";
 
         if ($this->firstHeadLevel === 0) {
             $this->firstHeadLevel = $level;
@@ -342,7 +342,7 @@ class ParsedownToC extends DynamicParent
         //     - [Header3](#Header3)
         //   - [Header2-2](#Header2-2)
         // ...
-        $this->contentsListString .= "${indent}- ${link}" . PHP_EOL;
+        $this->contentsListString .= "{$indent}- {$link}" . PHP_EOL;
     }
     protected $contentsListString = '';
     protected $firstHeadLevel = 0;
@@ -393,7 +393,7 @@ class ParsedownToC extends DynamicParent
         $toc_data = $this->contentsList();
         $toc_id   = $this->getIdAttributeToC();
         $needle  = '<p>' . $tag_origin . '</p>';
-        $replace = "<div id=\"${toc_id}\">${toc_data}</div>";
+        $replace = "<div id=\"{$toc_id}\">{$toc_data}</div>";
 
         return str_replace($needle, $replace, $html);
     }


### PR DESCRIPTION
Using ${var} in strings is deprecated, use {$var} instead.