### PR TITLE
feat: exclusion of ToC tag in body method via option argument (fixes #22)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true

--- a/Extension.php
+++ b/Extension.php
@@ -126,11 +126,23 @@ class ParsedownToC extends DynamicParent
      * Parses the given markdown string to an HTML string but it leaves the ToC
      * tag as is. It's an alias of the parent method "\DynamicParent::text()".
      *
-     * @param  string $text  Markdown string to be parsed.
-     * @return string        Parsed HTML string.
+     * @param  string $text          Markdown string to be parsed.
+     * @param  bool   $omit_toc_tag  (Optional, default is false) If true, the ToC tag will be excluded from
+     * @return string                Parsed HTML string.
      */
-    public function body($text)
+    public function body($text, $omit_toc_tag = false)
     {
+        // Exclude the ToC tag from parsing
+        if ($omit_toc_tag) {
+            $tag_origin  = $this->getTagToC();
+
+            // replace the ToC tag to empty string
+            $text = str_replace($tag_origin, '', $text);
+
+            // Parses the markdown text
+            return DynamicParent::text($text);
+        }
+
         $text = $this->encodeTagToHash($text);   // Escapes ToC tag temporary
         $html = DynamicParent::text($text);      // Parses the markdown text
         $html = $this->decodeTagFromHash($html); // Unescape the ToC tag

--- a/README.md
+++ b/README.md
@@ -6,16 +6,29 @@
 
 Listing Table of Contents Extension for [Parsedown](http://parsedown.org/).
 
-This [simple PHP file](https://github.com/KEINOS/parsedown-extension_table-of-contents/blob/master/Extension.php) extends [Parsedown Vanilla](https://github.com/erusev/parsedown) / [Parsedown Extra](https://github.com/erusev/parsedown-extra) to generate a list of header index (a.k.a. Table of Contents or ToC), from a markdown text given.
+This [simple and single PHP file](https://github.com/KEINOS/parsedown-extension_table-of-contents/blob/master/Extension.php) extends [Parsedown Vanilla](https://github.com/erusev/parsedown) / [Parsedown Extra](https://github.com/erusev/parsedown-extra) to generate a list of header index (a.k.a. Table of Contents or ToC), from a markdown text given.
+
+## Download the extension
+
+- [https://raw.githubusercontent.com/KEINOS/parsedown-extension_table-of-contents/refs/heads/master/Extension.php](https://raw.githubusercontent.com/KEINOS/parsedown-extension_table-of-contents/refs/heads/master/Extension.php)
+
+Place the above file in the same directory as `Parsedown.php` and/or `ParsedownExtra.php` files and include them in your PHP script.
 
 | Supported Version | SHA256 Hash |
 | :-- | :-- |
 | [![](https://img.shields.io/badge/Parsedown-%3D1.7.4-blue)](https://github.com/erusev/parsedown/releases "Supported Parsedown Version") | `af4a4b29f38b5a00b003a3b7a752282274c969e42dee88e55a427b2b61a2f38f` |
 | [![](https://img.shields.io/badge/ParsedownExtra-%3D0.8.1-blue)](https://github.com/erusev/parsedown-extra/releases "Supported Parsedown Extra Version") | `b0c6bd5280fc7dc1caab4f4409efcae9fb493823826f7999c27b859152494be7` |
 
+## Use composer
+
 ```bash
 composer require keinos/parsedown-toc
 ```
+
+## Basic Usage
+
+> [!NOTE]
+> If `composer` is not your thing, replace the `require` statement with the path to the `Extension.php` and `Parsedown.php` files.
 
 ```php
 $ cat ./parse_sample.php

--- a/samples/download/main.php
+++ b/samples/download/main.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once('Parsedown-1.7.3.php');
 require_once('Extension-1.0.0.php');
 

--- a/tests/issues/README.md
+++ b/tests/issues/README.md
@@ -1,0 +1,20 @@
+# Tests for Issues/Features
+
+Unlike other tests, each file placed in this directory must be a complete PHP file.
+
+The test runner will run each one separately, and will consider a status code of “0” to be an expected result, and a non-zero status code to be a test failure.
+
+## Requirements
+
+- The test file name must begin with "test_" and end with ".php". It should also contain a simple description of the test that is recognizable.
+  - E.g.:
+    - test_issue_1234.php
+    - test_feat_5678_do_something_cool.php
+    - test_body_golden_cases.php
+- The test must be a complete PHP file.
+- The test must return a status code of 0 to be considered successful.
+- The test must output to stdout what the test is doing and its result in the following format:
+  - E.g. :
+    - Success: "`issue #1234: X should be Y ... OK`"
+    - Failure: "`issue #1234: X should be Y ... NG (X is not Y got Z)`"
+- If the result needs more than one line, the results should be indented at least 2 spaces for readability.

--- a/tests/issues/assertion.php
+++ b/tests/issues/assertion.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Returns true if $actual and $expect strings are equal.
+ * It will print out the result of the test as well.
+ *
+ * @param  string $description  Description of the test.
+ * @param  string $actual       Actual result.
+ * @param  string $expect       Expected result.
+ * @return bool                 True if $actual and $expect are equal.
+ */
+function assertEqual($description, $actual, $expect)
+{
+    if ($actual !== $expect) {
+        echo $description . " ... NG (unexpected result)\n";
+        echo "  - Expected:\n" . preg_replace('/^/m', '    ', $expect) . "\n";
+        echo "  - Actual:\n"   . preg_replace('/^/m', '    ', $actual) . "\n";
+
+        return false;
+    }
+
+    echo $description . " ... OK\n";
+
+    return true;
+}

--- a/tests/issues/assertion.php
+++ b/tests/issues/assertion.php
@@ -12,7 +12,31 @@
 function assertEqual($description, $actual, $expect)
 {
     if ($actual !== $expect) {
-        echo $description . " ... NG (unexpected result)\n";
+        echo $description . " ... NG (inputs should be equal)\n";
+        echo "  - Expected:\n" . preg_replace('/^/m', '    ', $expect) . "\n";
+        echo "  - Actual:\n"   . preg_replace('/^/m', '    ', $actual) . "\n";
+
+        return false;
+    }
+
+    echo $description . " ... OK\n";
+
+    return true;
+}
+
+/**
+ * Returns true if $actual and $expect strings are NOT equal.
+ * It will print out the result of the test as well.
+ *
+ * @param  string $description  Description of the test.
+ * @param  string $actual       Actual result.
+ * @param  string $expect       Expected result.
+ * @return bool                 True if $actual and $expect are not equal.
+ */
+function assertNotEqual($description, $actual, $expect)
+{
+    if ($actual == $expect) {
+        echo $description . " ... NG (input should not be equal)\n";
         echo "  - Expected:\n" . preg_replace('/^/m', '    ', $expect) . "\n";
         echo "  - Actual:\n"   . preg_replace('/^/m', '    ', $actual) . "\n";
 

--- a/tests/issues/assertion.php
+++ b/tests/issues/assertion.php
@@ -1,49 +1,70 @@
 <?php
 
-/**
- * Returns true if $actual and $expect strings are equal.
- * It will print out the result of the test as well.
- *
- * @param  string $description  Description of the test.
- * @param  string $actual       Actual result.
- * @param  string $expect       Expected result.
- * @return bool                 True if $actual and $expect are equal.
- */
-function assertEqual($description, $actual, $expect)
-{
-    if ($actual !== $expect) {
-        echo $description . " ... NG (inputs should be equal)\n";
-        echo "  - Expected:\n" . preg_replace('/^/m', '    ', $expect) . "\n";
-        echo "  - Actual:\n"   . preg_replace('/^/m', '    ', $actual) . "\n";
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
-        return false;
+class Assertion
+{
+    public function __construct($indent)
+    {
+        $this->indent = $indent;
     }
 
-    echo $description . " ... OK\n";
+    private function msgDetails($actual, $expect)
+    {
+        $indentDouble = str_repeat($this->indent, 2);
+        $indentTriple = str_repeat($this->indent, 3);
 
-    return true;
-}
-
-/**
- * Returns true if $actual and $expect strings are NOT equal.
- * It will print out the result of the test as well.
- *
- * @param  string $description  Description of the test.
- * @param  string $actual       Actual result.
- * @param  string $expect       Expected result.
- * @return bool                 True if $actual and $expect are not equal.
- */
-function assertNotEqual($description, $actual, $expect)
-{
-    if ($actual == $expect) {
-        echo $description . " ... NG (input should not be equal)\n";
-        echo "  - Expected:\n" . preg_replace('/^/m', '    ', $expect) . "\n";
-        echo "  - Actual:\n"   . preg_replace('/^/m', '    ', $actual) . "\n";
-
-        return false;
+        return $indentDouble . "- Expected:\n" . preg_replace('/^/m', $indentTriple, $expect) . PHP_EOL .
+               $indentDouble . "- Actual:\n"   . preg_replace('/^/m', $indentTriple, $actual) . PHP_EOL;
     }
 
-    echo $description . " ... OK\n";
+    /**
+     * Returns true if $actual and $expect strings are equal.
+     * It will print out the result of the test as well.
+     *
+     * @param  string $description  Description of the test.
+     * @param  string $actual       Actual result.
+     * @param  string $expect       Expected result.
+     * @return bool                 True if $actual and $expect are equal.
+     */
+    public function equal($description, $actual, $expect)
+    {
+        echo $this->indent;
 
-    return true;
+        if ($actual !== $expect) {
+            echo $description . " ... NG (inputs should be equal)" . PHP_EOL;
+            echo $this->msgDetails($actual, $expect);
+
+            return false;
+        }
+
+        echo $description . " ... OK" . PHP_EOL;
+
+        return true;
+    }
+
+    /**
+     * Returns true if $actual and $expect strings are NOT equal.
+     * It will print out the result of the test as well.
+     *
+     * @param  string $description  Description of the test.
+     * @param  string $actual       Actual result.
+     * @param  string $expect       Expected result.
+     * @return bool                 True if $actual and $expect are not equal.
+     */
+    public function notEqual($description, $actual, $expect)
+    {
+        echo $this->indent;
+
+        if ($actual == $expect) {
+            echo $description . " ... NG (input should not be equal)" . PHP_EOL;
+            echo $this->msgDetails($actual, $expect);
+
+            return false;
+        }
+
+        echo $description . " ... OK" . PHP_EOL;
+
+        return true;
+    }
 }

--- a/tests/issues/test_feat_22_omit_toc_tag.php
+++ b/tests/issues/test_feat_22_omit_toc_tag.php
@@ -28,6 +28,8 @@ HEREDOC;
 
 // Run the test
 $Parsedown = new ParsedownToc();
-$actual = $Parsedown->body($input);
+
+$omitToC = true;
+$actual = $Parsedown->body($input, $omitToC);
 
 assertEqual($description, $actual, $expect) ? exit(0) : exit(1);

--- a/tests/issues/test_feat_22_omit_toc_tag.php
+++ b/tests/issues/test_feat_22_omit_toc_tag.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once(__DIR__ . '/assertion.php');
+require_once(__DIR__ . '/../../Parsedown.php');
+require_once(__DIR__ . '/../../Extension.php');
+
+$description = 'feature #22: allow omit the ToC tag in the body of the document';
+
+$input = <<<'HEREDOC'
+# FooBar
+
+`FooBar` is a library to ...
+
+[toc]
+
+## Installation
+
+Do some weird stuff right now.
+HEREDOC;
+
+// Golden case
+$expect = <<<'HEREDOC'
+<h1 id="FooBar" name="FooBar">FooBar</h1>
+<p><code>FooBar</code> is a library to ...</p>
+<h2 id="Installation" name="Installation">Installation</h2>
+<p>Do some weird stuff right now.</p>
+HEREDOC;
+
+// Run the test
+$Parsedown = new ParsedownToc();
+$actual = $Parsedown->body($input);
+
+assertEqual($description, $actual, $expect) ? exit(0) : exit(1);

--- a/tests/parser/parser-common.php
+++ b/tests/parser/parser-common.php
@@ -1,4 +1,6 @@
 <?php
+
+// phpcs:disable PSR1.Files.SideEffects -- ignore declaration for new symbols
 /**
  *  Common script.
  * ============================================================================
@@ -71,6 +73,7 @@ function execMethods($obj, $list_methods)
 function getMarkdownFromStdIn()
 {
     $array = array_map('trim', file('php://stdin'));
+
     return implode(PHP_EOL, $array);
 }
 
@@ -94,6 +97,7 @@ function getMethodsToExecute()
     if (empty($array)) {
         return array();
     }
+
     return $array;
 }
 

--- a/tests/parser/parser-vanilla.php
+++ b/tests/parser/parser-vanilla.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Simple script that uses Parsedown and the ToC (Table of Contents) extension.
  *

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # =============================================================================
 #  Note: To run the test, see the README.md in this directory.
 #

--- a/tests/test-runner/common-tests.sh
+++ b/tests/test-runner/common-tests.sh
@@ -310,7 +310,7 @@ for file_test in issues/test_*.php; do
     exit_status=$?
     echo "- TESTING: ${result}"
     if [ $exit_status -ne 0 ]; then
-        failed_tests=$(( failed_tests + 1 ))
+        failed_tests=$(( failed_tests + exit_status ))
     fi
 done
 

--- a/tests/test-runner/common-tests.sh
+++ b/tests/test-runner/common-tests.sh
@@ -302,9 +302,26 @@ for file_test in {test_vanilla,test_extra_}*.sh; do
 done
 echo
 
+echo 'Issues/Features'
+for file_test in issues/test_*.php; do
+    [[ -e "$file_test" ]] || break  # handle the case of no matched test files
+
+    result=$(php "${file_test}")
+    exit_status=$?
+    echo "- TESTING: ${result}"
+    if [ $exit_status -ne 0 ]; then
+        failed_tests=$(( failed_tests + 1 ))
+    fi
+done
+
+echo
+
+# Test Failure
 [ $failed_tests -ne 0 ] && {
     echo "Test done. ${failed_tests} test(s) failed."
     exit $STATUS_FAILURE
 }
+
+# Test Success
 echo 'Test done. All tests passed.'
 exit $STATUS_SUCCESS


### PR DESCRIPTION
This PR implements/fixes #22.

```diff
- public function body($text)
+ public function body($text, $omit_toc_tag=false)
```

```php
$Parsedown = new ParsedownToc();

$a = $Parsedown->body($input);       // ordinary
$b = $Parsedown->body($input, true); // omit `[toc]` tag in the output
```

